### PR TITLE
Add multi-monitor selection for ring light displays

### DIFF
--- a/RingLight/Features/RingLight/Controllers/RingLightController.swift
+++ b/RingLight/Features/RingLight/Controllers/RingLightController.swift
@@ -92,6 +92,7 @@ final class RingLightController {
 
     func applyPresetTemperature(_ kelvin: Double) {
         $temperature.withLock { $0 = kelvin }
+        pushUpdate()
     }
 
     func availableDisplays() -> [DisplayInfo] {

--- a/RingLight/Features/RingLight/Controllers/RingLightController.swift
+++ b/RingLight/Features/RingLight/Controllers/RingLightController.swift
@@ -8,8 +8,6 @@ import SwiftUI
 struct DisplayInfo: Identifiable, Hashable {
     let id: UInt32
     let name: String
-    
-    static let allDisplays = DisplayInfo(id: 0, name: "All Displays")
 }
 
 // MARK: - Ring Light Controller
@@ -53,8 +51,31 @@ final class RingLightController {
     }
 
     @ObservationIgnored
-    @Shared(.ringLightSelectedDisplayID) var selectedDisplayID: UInt32 = 0 {
+    @Shared(.ringLightSelectedDisplayIDs) var selectedDisplayIDs: String = "" {
         didSet { pushUpdate() }
+    }
+
+    var selectedDisplayIDSet: Set<UInt32> {
+        let ids = selectedDisplayIDs.split(separator: ",").compactMap { UInt32($0) }
+        return Set(ids)
+    }
+
+    func toggleDisplay(_ id: UInt32) {
+        var idSet = selectedDisplayIDSet
+        if idSet.contains(id) {
+            idSet.remove(id)
+        } else {
+            idSet.insert(id)
+        }
+        $selectedDisplayIDs.withLock {
+            $0 = idSet.sorted().map(String.init).joined(separator: ",")
+        }
+        pushUpdate()
+    }
+
+    func isDisplaySelected(_ id: UInt32) -> Bool {
+        let idSet = selectedDisplayIDSet
+        return idSet.isEmpty || idSet.contains(id)
     }
 
     var previewColor: Color {
@@ -75,8 +96,8 @@ final class RingLightController {
 
     func availableDisplays() -> [DisplayInfo] {
         @Dependency(\.screenClient) var screenClient
-        var displays = [DisplayInfo.allDisplays]
-        
+        var displays: [DisplayInfo] = []
+
         let screens = screenClient.screens()
         for (index, screen) in screens.enumerated() {
             if let identifier = ScreenIdentifier(screen: screen) {
@@ -84,7 +105,7 @@ final class RingLightController {
                 displays.append(DisplayInfo(id: identifier.rawValue, name: name))
             }
         }
-        
+
         return displays
     }
 
@@ -100,6 +121,6 @@ final class RingLightController {
     }
 
     private func pushUpdate() {
-        engine.update(isEnabled: isEnabled, configuration: configuration, selectedDisplayID: selectedDisplayID)
+        engine.update(isEnabled: isEnabled, configuration: configuration, selectedDisplayIDs: selectedDisplayIDSet)
     }
 }

--- a/RingLight/Features/RingLight/Engine/RingLightEngine.swift
+++ b/RingLight/Features/RingLight/Engine/RingLightEngine.swift
@@ -7,7 +7,7 @@ import Dependencies
 final class RingLightEngine {
     private var configuration = RingLightConfiguration.default
     private var isEnabled = false
-    private var selectedDisplayID: UInt32 = 0
+    private var selectedDisplayIDs: Set<UInt32> = []
     private var windows: [ScreenIdentifier: RingLightWindow] = [:]
     private var screenObserver: NSObjectProtocol?
     private let screenClient: ScreenClient
@@ -32,10 +32,10 @@ final class RingLightEngine {
         }
     }
 
-    func update(isEnabled: Bool, configuration: RingLightConfiguration, selectedDisplayID: UInt32) {
+    func update(isEnabled: Bool, configuration: RingLightConfiguration, selectedDisplayIDs: Set<UInt32>) {
         self.configuration = configuration
         self.isEnabled = isEnabled
-        self.selectedDisplayID = selectedDisplayID
+        self.selectedDisplayIDs = selectedDisplayIDs
 
         if isEnabled {
             realizeWindowsIfNeeded()
@@ -58,8 +58,8 @@ final class RingLightEngine {
     private func realizeWindowsIfNeeded() {
         let currentScreens = screenClient.screens().compactMap { screen -> (ScreenIdentifier, NSScreen)? in
             guard let identifier = ScreenIdentifier(screen: screen) else { return nil }
-            // Filter by selected display: 0 means all displays
-            if selectedDisplayID != 0 && identifier.rawValue != selectedDisplayID {
+            // Filter by selected displays: empty set means all displays
+            if !selectedDisplayIDs.isEmpty && !selectedDisplayIDs.contains(identifier.rawValue) {
                 return nil
             }
             return (identifier, screen)

--- a/RingLight/Features/RingLight/Engine/RingLightMetalRenderer.swift
+++ b/RingLight/Features/RingLight/Engine/RingLightMetalRenderer.swift
@@ -61,6 +61,7 @@ final class HDRRingLightRenderer: NSObject, MTKViewDelegate {
             mtkView.colorspace = CGColorSpace(name: CGColorSpace.displayP3)
         }
 
+        mtkView.autoResizeDrawable = false
         mtkView.autoresizingMask = [.width, .height]
         mtkView.translatesAutoresizingMaskIntoConstraints = true
 
@@ -98,6 +99,7 @@ final class HDRRingLightRenderer: NSObject, MTKViewDelegate {
 
     func drawableSizeDidChange(to size: CGSize, scale: CGFloat) {
         drawableScale = max(scale, 1)
+        mtkView.frame = CGRect(origin: .zero, size: size)
         mtkView.drawableSize = CGSize(
             width: max(size.width * drawableScale, 1),
             height: max(size.height * drawableScale, 1)

--- a/RingLight/Features/RingLight/Engine/RingLightWindow.swift
+++ b/RingLight/Features/RingLight/Engine/RingLightWindow.swift
@@ -34,6 +34,10 @@ final class RingLightWindow: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        return frameRect
+    }
+
     func update(for screen: NSScreen) {
         setFrame(screen.frame, display: true)
         glowView.frame = NSRect(origin: .zero, size: screen.frame.size)
@@ -97,7 +101,10 @@ final class GlowGradientView: NSView {
     }
 
     private func syncScaleAndDrawableSize() {
-        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1
+        // Don't update if the view is being removed from its window (during teardown).
+        // Using a stale nil-screen fallback would reset the drawable to the wrong scale.
+        guard let screen = window?.screen else { return }
+        let scale = screen.backingScaleFactor
         metalRenderer?.drawableSizeDidChange(to: bounds.size, scale: scale)
     }
 
@@ -146,12 +153,10 @@ final class GlowGradientView: NSView {
             gradient.isHidden = configuration.intensity <= 0.01
         }
 
-        // Account for ring width to prevent clipping into menu bar
-        let effectiveTopInset = clamp(topSafeInset + targetWidth, min: 0, max: bounds.height)
-        let availableHeight = max(bounds.height - effectiveTopInset, 0)
-        
-        // Position top gradient: extends from topGradientY upward by topGradientHeight
-        // Clamped to ensure it stays within the available drawing area
+        // Reserve space for the menu bar / notch at the top
+        let availableHeight = max(bounds.height - topSafeInset, 0)
+
+        // Position top gradient just below the menu bar, extending inward by targetWidth
         let topGradientY = max(0, availableHeight - targetWidth)
         let topGradientHeight = min(targetWidth, availableHeight)
 

--- a/RingLight/Features/RingLight/Models/RingLightSettings.swift
+++ b/RingLight/Features/RingLight/Models/RingLightSettings.swift
@@ -18,7 +18,7 @@ struct RingLightSettings: Sendable, Equatable {
     var temperature: Double = 5200
     var cornerRadius: Double = 0
     var edgeInset: Double = 0
-    var selectedDisplayID: UInt32 = 0 // 0 means all displays
+    var selectedDisplayIDs: String = "" // comma-separated UInt32 values; empty means all displays
 }
 
 // MARK: - Codable Conformance (non-isolated)
@@ -33,7 +33,7 @@ extension RingLightSettings: Codable {
         self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature) ?? 5200
         self.cornerRadius = try container.decodeIfPresent(Double.self, forKey: .cornerRadius) ?? 0
         self.edgeInset = try container.decodeIfPresent(Double.self, forKey: .edgeInset) ?? 0
-        self.selectedDisplayID = try container.decodeIfPresent(UInt32.self, forKey: .selectedDisplayID) ?? 0
+        self.selectedDisplayIDs = try container.decodeIfPresent(String.self, forKey: .selectedDisplayIDs) ?? ""
     }
 
     nonisolated func encode(to encoder: Encoder) throws {
@@ -45,7 +45,7 @@ extension RingLightSettings: Codable {
         try container.encode(self.temperature, forKey: .temperature)
         try container.encode(self.cornerRadius, forKey: .cornerRadius)
         try container.encode(self.edgeInset, forKey: .edgeInset)
-        try container.encode(self.selectedDisplayID, forKey: .selectedDisplayID)
+        try container.encode(self.selectedDisplayIDs, forKey: .selectedDisplayIDs)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -56,7 +56,7 @@ extension RingLightSettings: Codable {
         case temperature
         case cornerRadius
         case edgeInset
-        case selectedDisplayID
+        case selectedDisplayIDs
     }
 }
 
@@ -95,8 +95,8 @@ extension SharedKey where Self == AppStorageKey<Double>.Default {
     }
 }
 
-extension SharedKey where Self == AppStorageKey<UInt32>.Default {
-    static var ringLightSelectedDisplayID: Self {
-        Self[.appStorage("ringLight:selectedDisplayID"), default: 0]
+extension SharedKey where Self == AppStorageKey<String>.Default {
+    static var ringLightSelectedDisplayIDs: Self {
+        Self[.appStorage("ringLight:selectedDisplayIDs"), default: ""]
     }
 }

--- a/RingLight/Features/RingLight/Shaders/RingLightShader.metal
+++ b/RingLight/Features/RingLight/Shaders/RingLightShader.metal
@@ -47,9 +47,8 @@ float sdRoundedBox(float2 p, float2 halfSize, float radius) {
 fragment half4 ringLightFragment(VertexOut in [[stage_in]],
                                  constant RingLightUniforms& uniforms [[buffer(0)]]) {
     float2 coord = in.uv * uniforms.resolution;
-    // Account for ring width to prevent clipping into menu bar
-    float effectiveTopInset = uniforms.safeTopInset + uniforms.ringWidth;
-    float cappedHeight = uniforms.resolution.y - effectiveTopInset;
+    // Clip the top area reserved for the menu bar / notch
+    float cappedHeight = uniforms.resolution.y - uniforms.safeTopInset;
     if (cappedHeight <= 0.0) {
         return half4(0.0);
     }

--- a/RingLight/Features/RingLight/Views/ContentView.swift
+++ b/RingLight/Features/RingLight/Views/ContentView.swift
@@ -90,18 +90,26 @@ struct ContentView: View {
 
     private var displayPickerSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text("DISPLAY")
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
-            
-            Picker("Display", selection: $controller.selectedDisplayID) {
-                ForEach(controller.availableDisplays()) { display in
-                    Text(display.name).tag(display.id)
+            HStack {
+                Text("DISPLAYS")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if controller.selectedDisplayIDSet.isEmpty {
+                    Text("All displays")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
                 }
             }
-            .pickerStyle(.menu)
-            .labelsHidden()
+
+            ForEach(controller.availableDisplays()) { display in
+                Toggle(display.name, isOn: Binding(
+                    get: { controller.selectedDisplayIDSet.contains(display.id) },
+                    set: { _ in controller.toggleDisplay(display.id) }
+                ))
+                .toggleStyle(.checkbox)
+            }
         }
     }
 

--- a/RingLight/Utilities/Extensions.swift
+++ b/RingLight/Utilities/Extensions.swift
@@ -45,10 +45,13 @@ extension NSColor {
 
 extension NSScreen {
     var menuBarInset: CGFloat {
-        if #available(macOS 12.0, *) {
-            return max(safeAreaInsets.top, NSStatusBar.system.thickness)
-        } else {
-            return NSStatusBar.system.thickness
+        // The gap between the top of the screen and the top of the visible
+        // area (below the menu bar + padding) matches where full-screen apps start.
+        let topInset = frame.maxY - visibleFrame.maxY
+        if topInset > 0 {
+            return topInset
         }
+        // Fallback for screens without a menu bar
+        return NSStatusBar.system.thickness
     }
 }


### PR DESCRIPTION
Replace the single-display picker with per-monitor checkboxes, allowing any combination of displays to show the ring light. An empty selection defaults to all displays. Also fixes ring light positioning on external monitors by correcting the shader's top inset calculation and using visibleFrame for accurate menu bar inset.


<img width="406" height="568" alt="Screenshot 2026-02-16 at 2 39 06 PM" src="https://github.com/user-attachments/assets/957e6f26-1ffa-4a23-b035-2e50c2784736" />
